### PR TITLE
Install fetch polyfill inside ravenous root

### DIFF
--- a/ravenous/.gitignore
+++ b/ravenous/.gitignore
@@ -1,7 +1,7 @@
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies
-/node_modules/*
+/node_modules
 /.pnp
 .pnp.js
 

--- a/ravenous/package.json
+++ b/ravenous/package.json
@@ -5,7 +5,8 @@
   "dependencies": {
     "react": "^16.7.0",
     "react-dom": "^16.7.0",
-    "react-scripts": "2.1.1"
+    "react-scripts": "2.1.1",
+    "whatwg-fetch": "^3.0.0"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
This pull request deletes node-module folder from my-codecademy-projects.
It install fetch() polyfill inside ravenous folder node-modules